### PR TITLE
Crude fixes to build and run on xubuntu 20.04.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -200,3 +200,15 @@ Keyboard shortcuts:
 Clicking or holding the left mouse button sets the time proportionally to
 the mouse X position within the window, up to the total number of frames.
 
+
+
+
+COMPILING
+
+
+Example: on Ubuntu 20.04
+
+    apt install libglfw3-dev portaudio19-dev
+
+    make -j -k && for a in ../examples/*rose ; do echo $a ; ./build/rose  $a ; done
+

--- a/visualizer/Makefile
+++ b/visualizer/Makefile
@@ -3,9 +3,10 @@ EXTERNAL := ../../Andres
 BUILD = build
 DIST_DIR = ../dist/Rose
 
-CC := i686-w64-mingw32-g++
-CFLAGS := -Iparser/rose -I$(EXTERNAL)/glfw-3.0.4.bin.WIN32/include -I$(EXTERNAL)/glew-1.10.0/include -I$(EXTERNAL)/portaudio/include -Wno-write-strings -std=c++11
-LFLAGS := $(EXTERNAL)/glew-1.10.0/lib/Release/Win32/glew32s.lib -L$(EXTERNAL)/glfw-3.0.4.bin.WIN32/lib-mingw $(EXTERNAL)/portaudio/mingw32/usr/local/lib/libportaudio-2.dll -lglfw3 -lopengl32 -luser32 -lgdi32 -static-libgcc -static-libstdc++
+CC := g++
+CFLAGS := $(shell pkg-config --libs portaudiocpp) -Iparser/rose -I$(EXTERNAL)/glfw-3.0.4.bin.WIN32/include -I$(EXTERNAL)/glew-1.10.0/include -I$(EXTERNAL)/portaudio/include -Wno-write-strings -std=c++11
+#LFLAGS := $(EXTERNAL)/glew-1.10.0/lib/Release/Win32/glew32s.lib -L$(EXTERNAL)/glfw-3.0.4.bin.WIN32/lib-mingw $(EXTERNAL)/portaudio/mingw32/usr/local/lib/libportaudio-2.dll -lglfw3 -lopengl32 -luser32 -lgdi32 -static-libgcc -static-libstdc++
+LFLAGS := -static-libgcc -static-libstdc++ $(shell pkg-config --libs glfw3) $(shell pkg-config --libs glew) $(shell pkg-config --libs portaudiocpp)
 #CC := x86_64-w64-mingw32-g++
 #CFLAGS := -O3 -Iparser/rose -I$(EXTERNAL)/glfw-3.0.4.bin.WIN64/include -I$(EXTERNAL)/glew-1.10.0/include -I$(EXTERNAL)/portaudio/include -Wno-write-strings -std=c++11
 #LFLAGS := $(EXTERNAL)/glew-1.10.0/lib/Release/x64/glew32s.lib -L$(EXTERNAL)/glfw-3.0.4.bin.WIN64/lib-mingw -lglfw3 -luser32 -lopengl32 -lgdi32 -static-libgcc -static-libstdc++ -s
@@ -19,7 +20,7 @@ endif
 
 $(BUILD)/rose: $(patsubst %,$(BUILD)/%.o,main translate renderer music) $(patsubst parser/%.cpp,$(BUILD)/%.o,$(wildcard parser/*.cpp))
 	$(CC) $^ $(LFLAGS) -o $(BUILD)/rose
-	cp lib/* $(BUILD)/
+#	cp lib/* $(BUILD)/
 
 $(BUILD)/%.o: %.cpp Makefile
 	$(CC) $(CFLAGS) $< -c -o $@

--- a/visualizer/main.cpp
+++ b/visualizer/main.cpp
@@ -235,10 +235,12 @@ int main(int argc, char *argv[]) {
 
 		if (playing && project) {
 			int prev_frame = frame;
-			do {
-				usleep(1000);
-				frame = (int)(player.get_time() * framerate);
-			} while (frame == prev_frame);
+			//do {
+			//	usleep(1000);
+			//	frame = (int)(player.get_time() * framerate);
+			//} while (frame == prev_frame);
+                        frame++;
+                        usleep(20);
 		} else {
 			usleep(100000);
 		}


### PR DESCRIPTION
Hi Aske!

Old Amiga fan here. Played with Rose moments ago. Makefile contains hacks (mingw-specific, local hacks).

Did some quick and crude cleanup to have it work on a Xubuntu 20.04 box. Mostly makefile, and also time was stuck on first frame so I hacked crudely. This was enough to see the examples.
Looks like some are intended to be in sync with some music.
I spotted the reference to "State of the Art" demo!

The changes in this PR are obviously not intended to be merged as is, but can be a base, should you be open to other people reusing your work.

Cheers!